### PR TITLE
Include Jenkinsfile in .helmignore

### DIFF
--- a/.helmignore
+++ b/.helmignore
@@ -20,3 +20,6 @@
 .idea/
 *.tmproj
 .vscode/
+
+# Custom files
+Jenkinsfile


### PR DESCRIPTION
As an end user, I see no reason to have the Jenkinsfile included in the packaged chart. But if your CI system needs it in the packaged and delivered chart, feel free to abandon this PR. :)